### PR TITLE
Feat/rpai world subsystem

### DIFF
--- a/Source/ReasonablePlanningAI/Private/BTTask/RpaiBTTask_ExecutePlannedGoal.cpp
+++ b/Source/ReasonablePlanningAI/Private/BTTask/RpaiBTTask_ExecutePlannedGoal.cpp
@@ -210,7 +210,7 @@ void URpaiBTTask_ExecutePlannedGoal::DescribeRuntimeValues(const UBehaviorTreeCo
 	{
 		FExecutePlannedGoalMemory* PlannedGoalMemory = (FExecutePlannedGoalMemory*)NodeMemory;
 
-		static const UEnum* RpaiPlannerResultEnumType = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERpaiPlannerResult"));
+		static const UEnum* RpaiPlannerResultEnumType = StaticEnum<ERpaiPlannerResult>();
 		check(RpaiPlannerResultEnumType != nullptr);
 		FString LastPlannerResultForMultiTickString = RpaiPlannerResultEnumType->GetNameStringByIndex(static_cast<uint8>(PlannedGoalMemory->LastPlanningResult));
 		Values.Add(FString::Printf(TEXT("Last Planning Result: %s\n"), *LastPlannerResultForMultiTickString));

--- a/Source/ReasonablePlanningAI/Private/Core/RpaiSubsystem.cpp
+++ b/Source/ReasonablePlanningAI/Private/Core/RpaiSubsystem.cpp
@@ -1,10 +1,24 @@
 #include "Core/RpaiSubsystem.h"
+#include "Core/RpaiPlannerBase.h"
 
 const URpaiPlannerBase* URpaiSubsystem::DuplicateOrGetPlannerInstanceInWorldScope(const URpaiPlannerBase* Template)
 {
     if (!IsValid(Template))
     {
         return nullptr;
+    }
+    else if (GetWorld()->IsPlayInEditor())
+    {
+        auto Found = InstantiatedTemplates.Find(Template);
+        if (Found != nullptr)
+        {
+            return *Found;
+        }
+        else
+        {
+            auto Instance = InstantiatedTemplates.Add(Template, Cast<URpaiPlannerBase>(StaticDuplicateObject(Template, this)));
+            return Instance;
+        }
     }
     else if(Template->GetWorld() != GetWorld())
     {

--- a/Source/ReasonablePlanningAI/Private/Core/RpaiSubsystem.cpp
+++ b/Source/ReasonablePlanningAI/Private/Core/RpaiSubsystem.cpp
@@ -1,0 +1,39 @@
+#include "Core/RpaiSubsystem.h"
+
+const URpaiPlannerBase* URpaiSubsystem::DuplicateOrGetPlannerInstanceInWorldScope(const URpaiPlannerBase* Template)
+{
+    if (!IsValid(Template))
+    {
+        return nullptr;
+    }
+    else if(Template->GetWorld() != GetWorld())
+    {
+        auto Found = InstantiatedTemplates.Find(Template);
+        if(Found != nullptr)
+        {
+            return *Found;
+        }
+        else
+        {
+            auto Instance = InstantiatedTemplates.Add(Template, Cast<URpaiPlannerBase>(StaticDuplicateObject(Template, this)));
+            return Instance;
+        }
+    }
+    else if (Template->HasAnyFlags(RF_ClassDefaultObject))
+    {
+        auto Found = InstantiatedTemplates.Find(Template);
+        if(Found != nullptr)
+        {
+            return *Found;
+        }
+        else
+        {
+            auto Instance = InstantiatedTemplates.Add(Template, Cast<URpaiPlannerBase>(StaticDuplicateObject(Template, this)));
+            return Instance;
+        }
+    }
+    else
+    {
+        return Template;
+    }
+}

--- a/Source/ReasonablePlanningAI/Private/Core/RpaiTypes.cpp
+++ b/Source/ReasonablePlanningAI/Private/Core/RpaiTypes.cpp
@@ -142,6 +142,18 @@ FRpaiMemoryStruct::FRpaiMemoryStruct(FRpaiMemory* FromMemory, UScriptStruct* Fro
 		Type->InitializeDefaultValue(MemoryStart);
 	}
 
+	/**
+	* The intended uses of the struct types loaded by this "memory manager" is to provide
+	* dynamic creation and storage of structs in both C++ and Blueprints. A consequence of this
+	* is that the USTRUCT never really makes an appearance in the Asset, Editor, or Game CDOs or 
+	* objects tracked for garbage collection. This means that if a USTRUCT used in this manner contains
+	* a strong pointer to a UObject (via UPROPERTY or TSharedPtr and fam) it will not actually get
+	* tracked properly by the GC, but for all intents it is a valid object. IsValid calls will be true but
+	* IsUnreachable will also be true! By post loading here we can ensure that the proper object references
+	* are tracked. This keeps it simple for compatible experience across C++ and Blueprints.
+	**/
+	Type->PostLoad();
+
 	AddRef();
 }
 

--- a/Source/ReasonablePlanningAI/Private/Planners/RpaiPlanner_AStar.cpp
+++ b/Source/ReasonablePlanningAI/Private/Planners/RpaiPlanner_AStar.cpp
@@ -26,28 +26,33 @@ ERpaiPlannerResult URpaiPlanner_AStar::ReceiveStartGoalPlanning_Implementation(
     FAStarPlannerMemory* Memory = PlannerMemory.Get<FAStarPlannerMemory>();
     Memory->OpenActions.Empty();
     Memory->ClosedActions.Empty();
+    Memory->VisitedStates.Empty();
+    Memory->UnorderedNodes.Empty();
     Memory->CurrentIterations = 0;
     Memory->FutureState = nullptr;
-    Memory->DisposableRoot = nullptr;
 
     if (TargetGoal->IsInDesiredState(CurrentState))
     {
         return ERpaiPlannerResult::CompletedSuccess;
     }
-    Memory->DisposableRoot = NewObject<UObject>(GetTransientPackage(), CurrentState->GetClass());
 
-    FVisitedState Start;
-    Start.Id = FGuid::NewGuid();
-    Start.Action = nullptr;
+    FVisitedState& Start = Memory->UnorderedNodes.AddDefaulted_GetRef();
+    Start.SelfIndex = Memory->UnorderedNodes.Num() - 1;
     Start.Cost = 0.f;
     Start.Remaining = 0.f;
-    Start.ParentId.Invalidate();
-    Start.State = NewObject<URpaiState>(Memory->DisposableRoot, CurrentState->GetClass());
+    Start.StateIndex = INDEX_NONE;
+    Start.ParentIndex = INDEX_NONE;
+    Start.Action = nullptr;
 
-    CurrentState->CopyStateForPredictionTo(Start.State);
+    const FText FormattedName = FText::Format(FText::FromString(FString("RootState_{0}")), FText::FromString(FGuid::NewGuid().ToString()));
+    URpaiState* StartState = NewObject<URpaiState>(const_cast<URpaiPlanner_AStar*>(this), CurrentState->GetClass(), FName(FormattedName.ToString()));
+    int32 RootIndex = Memory->VisitedStates.Add(StartState);
+
+    Start.StateIndex = RootIndex;
+    CurrentState->CopyStateForPredictionTo(StartState);
 
     Memory->OpenActions.HeapPush(Start);
-    Memory->FutureState = NewObject<URpaiState>(Memory->DisposableRoot, CurrentState->GetClass());
+    Memory->FutureState = NewObject<URpaiState>(const_cast<URpaiPlanner_AStar*>(this), CurrentState->GetClass(), TEXT("FutureState"));
     return ERpaiPlannerResult::RequiresTick;
 }
 
@@ -68,61 +73,71 @@ ERpaiPlannerResult URpaiPlanner_AStar::ReceiveTickGoalPlanning_Implementation(
         Memory->OpenActions.HeapPop(Current);
         Memory->ClosedActions.Push(Current);
 
-        if (TargetGoal->IsInDesiredState(Current.State))
+        check(Memory->VisitedStates.IsValidIndex(Current.StateIndex));
+        URpaiState* CurrentVisitedState = Memory->VisitedStates[Current.StateIndex];
+        if (TargetGoal->IsInDesiredState(CurrentVisitedState))
         {
-            do
+            for(;;)
             {
-                OutActions.Push(Current.Action);
-                auto Next = Memory->OpenActions.FindByKey(Current.ParentId);
-                if (Next == nullptr)
+                OutActions.Push(Memory->UnorderedNodes[Current.SelfIndex].Action);
+                if (Current.ParentIndex > 0 /*Ignore root node*/ && Memory->UnorderedNodes.IsValidIndex(Current.ParentIndex))
                 {
-                    Next = Memory->ClosedActions.FindByKey(Current.ParentId);
-                }
-                Current = *Next;
-            } while (Current.ParentId.IsValid());
-            Memory->DisposableRoot->ConditionalBeginDestroy();
-            return ERpaiPlannerResult::CompletedSuccess;
-        }
-
-        for (const auto& Action : GivenActions)
-        {
-            if (Action->IsApplicable(Current.State))
-            {
-                Current.State->CopyStateForPredictionTo(Memory->FutureState);
-                Action->ApplyToState(Memory->FutureState);
-
-                if (Memory->ClosedActions.FindByKey(Memory->FutureState) != nullptr)
-                {
-                    continue;
-                }
-
-                FVisitedState* InOpen = Memory->OpenActions.FindByKey(Memory->FutureState);
-                auto ActionCost = Action->ExecutionWeight(Current.State);
-                auto NewCost = Current.Cost + ActionCost;
-                auto NewRemaining = TargetGoal->GetDistanceToDesiredState(Memory->FutureState);
-
-                if (InOpen == nullptr)
-                {
-                    FVisitedState NewNode;
-                    NewNode.Id = FGuid::NewGuid();
-                    NewNode.Action = Action;
-                    NewNode.Cost = NewCost;
-                    NewNode.Remaining = NewRemaining;
-                    NewNode.ParentId = Current.Id;
-                    NewNode.State = NewObject<URpaiState>(Memory->DisposableRoot, CurrentState->GetClass());
-                    Memory->FutureState->CopyStateForPredictionTo(NewNode.State);
-
-                    Memory->OpenActions.HeapPush(NewNode);
+                    Current = Memory->UnorderedNodes[Current.ParentIndex];
                 }
                 else
                 {
-                    if (NewCost < InOpen->Cost)
+                    break;
+                }
+            }
+            CleanupInstanceMemory(Memory);
+            return ERpaiPlannerResult::CompletedSuccess;
+        }
+        else
+        {
+            for (const auto& Action : GivenActions)
+            {
+                if (Action->IsApplicable(CurrentVisitedState))
+                {
+                    // GC Buster
+                    if (Memory->FutureState->IsUnreachable())
                     {
-                        InOpen->ParentId = Current.Id;
-                        InOpen->Cost = NewCost;
-                        InOpen->Action = Action;
-                        InOpen->Remaining = NewRemaining;
+                        Memory->FutureState = NewObject<URpaiState>(const_cast<URpaiPlanner_AStar*>(this), CurrentState->GetClass(), TEXT("FutureState"));
+                    }
+                    CurrentVisitedState->CopyStateForPredictionTo(Memory->FutureState);
+                    Action->ApplyToState(Memory->FutureState);
 
+                    if (Memory->ClosedActions.IsValidIndex(FindEqualNodeFromState(Memory->FutureState, Memory->VisitedStates, Memory->ClosedActions)))
+                    {
+                        continue;
+                    }
+
+                    auto ActionCost = Action->ExecutionWeight(CurrentVisitedState);
+                    auto NewCost = Current.Cost + ActionCost;
+                    auto NewRemaining = TargetGoal->GetDistanceToDesiredState(Memory->FutureState);
+
+                    int32 OpenIndex = FindEqualNodeFromState(Memory->FutureState, Memory->VisitedStates, Memory->OpenActions);
+                    if (!Memory->OpenActions.IsValidIndex(OpenIndex))
+                    {
+                        FVisitedState& NewNode = Memory->UnorderedNodes.AddDefaulted_GetRef();
+                        NewNode.SelfIndex = Memory->UnorderedNodes.Num() - 1;
+                        NewNode.Action = Action;
+                        NewNode.Cost = NewCost;
+                        NewNode.Remaining = NewRemaining;
+                        NewNode.ParentIndex = Current.SelfIndex;
+
+                        auto NewState = NewObject<URpaiState>(const_cast<URpaiPlanner_AStar*>(this), CurrentState->GetClass());
+                        Memory->FutureState->CopyStateForPredictionTo(NewState);
+                        NewNode.StateIndex = Memory->VisitedStates.Add(NewState);
+
+                        // add the number of actions preceeding this action
+                        Memory->OpenActions.HeapPush(NewNode);
+                    }
+                    else if (NewCost < Memory->OpenActions[OpenIndex].Cost)
+                    {
+                        Memory->OpenActions[OpenIndex].ParentIndex = Current.SelfIndex;
+                        Memory->OpenActions[OpenIndex].Cost = NewCost;
+                        Memory->OpenActions[OpenIndex].Action = Action;
+                        Memory->OpenActions[OpenIndex].Remaining = NewRemaining;
                         Memory->OpenActions.HeapSort();
                     }
                 }
@@ -132,10 +147,23 @@ ERpaiPlannerResult URpaiPlanner_AStar::ReceiveTickGoalPlanning_Implementation(
 
     if (Memory->CurrentIterations >= MaxIterations || Memory->OpenActions.IsEmpty())
     {
-        Memory->DisposableRoot->ConditionalBeginDestroy();
+        CleanupInstanceMemory(Memory);
         return ERpaiPlannerResult::CompletedFailure;
     }
     return ERpaiPlannerResult::RequiresTick;
+}
+
+int32 URpaiPlanner_AStar::FindEqualNodeFromState(const URpaiState* Lookup, const TArray<TObjectPtr<URpaiState>>& States, const TArray<FVisitedState>& Nodes)
+{
+    for (int32 Idx = 0; Idx < Nodes.Num(); ++Idx)
+    {
+        auto NodeState = States[Nodes[Idx].StateIndex];
+        if (Lookup->IsEqualTo(NodeState))
+        {
+            return Idx;
+        }
+    }
+    return INDEX_NONE;
 }
 
 ERpaiPlannerResult URpaiPlanner_AStar::ReceiveCancelGoalPlanning_Implementation(
@@ -179,4 +207,26 @@ bool URpaiPlanner_AStar::ReceivePlanChosenGoal_Implementation(
         );
     }
     return Result == ERpaiPlannerResult::CompletedSuccess ? true : false;
+}
+
+void URpaiPlanner_AStar::CleanupInstanceMemory(FAStarPlannerMemory* Memory) const
+{
+    check(Memory != nullptr);
+    if (IsValid(Memory->FutureState))
+    {
+        Memory->FutureState->ConditionalBeginDestroy();
+    }
+
+    for (auto& State : Memory->VisitedStates)
+    {
+        if (IsValid(State))
+        {
+            State->ConditionalBeginDestroy();
+        }
+    }
+
+    Memory->OpenActions.Empty();
+    Memory->ClosedActions.Empty();
+    Memory->VisitedStates.Empty();
+    Memory->UnorderedNodes.Empty();
 }

--- a/Source/ReasonablePlanningAI/Public/Core/RpaiBrainComponent.h
+++ b/Source/ReasonablePlanningAI/Public/Core/RpaiBrainComponent.h
@@ -113,6 +113,8 @@ private:
 	FRpaiMemoryStruct CurrentPlannerMemory;
 
 	ERpaiPlannerResult LastPlannerResultForMultiTick;
+    
+    const URpaiPlannerBase* DoAcquirePlanner();
 	
 public:
 	FORCEINLINE const URpaiActionBase* GetCurrentAction() const { return CurrentAction; }

--- a/Source/ReasonablePlanningAI/Public/Core/RpaiSubsystem.h
+++ b/Source/ReasonablePlanningAI/Public/Core/RpaiSubsystem.h
@@ -32,5 +32,6 @@ public:
     }
     
 private:
-    TMap<const URpaiPlannerBase*, const URpaiPlannerBase*> InstantiatedTemplates;    
+    UPROPERTY(Transient)
+    TMap<const URpaiPlannerBase*, const URpaiPlannerBase*> InstantiatedTemplates;
 };

--- a/Source/ReasonablePlanningAI/Public/Core/RpaiSubsystem.h
+++ b/Source/ReasonablePlanningAI/Public/Core/RpaiSubsystem.h
@@ -1,0 +1,36 @@
+// Troll Purse. All rights reserved.
+
+#pragma once
+
+#include "Subsystems/WorldSubsystem.h"
+#include "RpaiSubsystem.generated.h"
+
+class URpaiPlannerBase;
+
+/**
+ * World scoped execution of core components of Rpai.
+ */
+UCLASS()
+class REASONABLEPLANNINGAI_API URpaiSubsystem : public UWorldSubsystem
+{
+    GENERATED_BODY()
+    
+public:
+    
+    /**
+     * Given a pointer to an instance to a planner, create a duplicate object if there exists no cached entry, the template is a class default, or it is not of the UWorld scoped to this World Subsystem.
+     */
+    UFUNCTION()
+    const URpaiPlannerBase* DuplicateOrGetPlannerInstanceInWorldScope(const URpaiPlannerBase* Template);
+    
+    /**
+     * Convenience getter to get the subsystem for the given UWorld
+     */
+    FORCEINLINE static URpaiSubsystem* GetCurrent(const UWorld* InWorld)
+    {
+        return UWorld::GetSubsystem<URpaiSubsystem>(InWorld);
+    }
+    
+private:
+    TMap<const URpaiPlannerBase*, const URpaiPlannerBase*> InstantiatedTemplates;    
+};

--- a/Source/ReasonablePlanningAI/Public/Planners/RpaiPlanner_HUG.h
+++ b/Source/ReasonablePlanningAI/Public/Planners/RpaiPlanner_HUG.h
@@ -12,11 +12,25 @@ struct FHugPlannerMemory
 {
 	GENERATED_BODY()
 
+	UPROPERTY()
 	TArray<FVisitedState> OpenActions; // all of the open actions to be explored
+
+	UPROPERTY()
 	TArray<FVisitedState> ClosedActions; // all of the closed actions terminating
+
+	UPROPERTY()
+	TArray<TObjectPtr<URpaiState>> VisitedStates;
+
+	UPROPERTY()
+	TArray<FVisitedState> UnorderedNodes;
+
+	UPROPERTY()
 	int32 CurrentIterations; // used the track the number of executions to plan
+
+	UPROPERTY()
 	URpaiState* FutureState; // cached state scratch pad for projection
-	UObject* DisposableRoot; // used as the root for new Objects
+
+	UPROPERTY()
 	float OriginalWeight; // used to detect divergence.
 };
 
@@ -80,4 +94,9 @@ protected:
 		TArray<URpaiActionBase*>& OutActions,
 		FRpaiMemoryStruct PlannerMemory
 	) const override;
+
+private:
+	void CleanupInstanceMemory(FHugPlannerMemory* Memory) const;
+
+	static int32 FindEqualNodeFromState(const URpaiState* Lookup, const TArray<TObjectPtr<URpaiState>>& States, const TArray<FVisitedState>& Nodes);
 };

--- a/Source/ReasonablePlanningAI/ReasonablePlanningAI.Build.cs
+++ b/Source/ReasonablePlanningAI/ReasonablePlanningAI.Build.cs
@@ -7,15 +7,6 @@ public class ReasonablePlanningAI : ModuleRules
 	public ReasonablePlanningAI(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		
-		PublicIncludePaths.AddRange(
-			new string[]
-            {
-                "ReasonablePlanningAI/Public"
-            }
-			);
-				
-		
 		PrivateIncludePaths.AddRange(
 			new string[]
             {

--- a/Source/ReasonablePlanningAINodes/ReasonablePlanningAINodes.Build.cs
+++ b/Source/ReasonablePlanningAINodes/ReasonablePlanningAINodes.Build.cs
@@ -6,14 +6,7 @@ namespace UnrealBuildTool.Rules
 	{
 		public ReasonablePlanningAINodes(ReadOnlyTargetRules Target) : base(Target)
 		{
-            PublicIncludePaths.AddRange(
-				new[] {
-                	"ReasonablePlanningAINodes/Public"
-                }
-			);
-				
-		
-			PrivateIncludePaths.AddRange(
+            PrivateIncludePaths.AddRange(
 				new[] {
 					"ReasonablePlanningAINodes/Private"
 				}


### PR DESCRIPTION
URpaiPlanner was causing GC collection reference errors when referencing UObjects stored in Memory Structs. This contains some better object root tracking and world scoped planners. Biggest fix is the call to the PostLoad event on the struct type.