### PR TITLE
[BREAKING CHANGE]: State Refactor to use structs and property bindings

### DIFF
--- a/Source/ReasonablePlanningAI/Private/Composer/RPAIComposerBrainComponent.cpp
+++ b/Source/ReasonablePlanningAI/Private/Composer/RPAIComposerBrainComponent.cpp
@@ -17,6 +17,8 @@ void URpaiComposerBrainComponent::SetReasonablePlanningBehavior(URpaiComposerBeh
 		if (World == nullptr || !World->IsGameWorld())
 		{
 			ReasonablePlanningBehavior = NewBehavior;
+			DefaultStateType = NewBehavior->GetConstructedStateType();
+			ClearCachedStateInstance();
 		}
 		else
 		{
@@ -25,10 +27,36 @@ void URpaiComposerBrainComponent::SetReasonablePlanningBehavior(URpaiComposerBeh
 				StopLogic("New Behavior");
 			}
 			ReasonablePlanningBehavior = NewBehavior;
+			DefaultStateType = NewBehavior->GetConstructedStateType();
+			ClearCachedStateInstance();
 			StartLogic();
 		}
 	}
 }
+
+void URpaiComposerBrainComponent::OnRegister()
+{
+	Super::OnRegister();
+	if (IsValid(ReasonablePlanningBehavior))
+	{
+		DefaultStateType = ReasonablePlanningBehavior->GetConstructedStateType();
+	}
+}
+
+#if WITH_EDITOR
+void URpaiComposerBrainComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+	static const FName NAME_ReasonablePlanningBehavior = GET_MEMBER_NAME_CHECKED(URpaiComposerBrainComponent, ReasonablePlanningBehavior);
+
+	const FName ChangedPropertyName = PropertyChangedEvent.GetPropertyName();
+
+	if (ChangedPropertyName == NAME_ReasonablePlanningBehavior)
+	{
+		DefaultStateType = ReasonablePlanningBehavior->GetConstructedStateType();
+	}
+}
+#endif
 
 const URpaiReasonerBase* URpaiComposerBrainComponent::AcquireReasoner_Implementation()
 {
@@ -56,14 +84,4 @@ void URpaiComposerBrainComponent::AcquireActions_Implementation(TArray<URpaiActi
 	{
 		OutActions = ReasonablePlanningBehavior->GetActions();
 	}
-}
-
-TSubclassOf<URpaiState> URpaiComposerBrainComponent::GetStateType_Implementation()
-{
-    if(ReasonablePlanningBehavior)
-    {
-        return ReasonablePlanningBehavior->GetConstructedStateType();
-    }
-    
-	return URpaiState::StaticClass();
 }

--- a/Source/ReasonablePlanningAI/Private/Core/RpaiState.cpp
+++ b/Source/ReasonablePlanningAI/Private/Core/RpaiState.cpp
@@ -18,5 +18,5 @@ bool URpaiState::HasReferencedState(const FStateKeyValueReference& StateProperty
 
 void URpaiState::SetStateFromController_Implementation(const AAIController* FromController)
 {
-
+   
 }

--- a/Source/ReasonablePlanningAI/Public/Composer/RPAIComposerBrainComponent.h
+++ b/Source/ReasonablePlanningAI/Public/Composer/RPAIComposerBrainComponent.h
@@ -25,12 +25,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Rpai")
 	void SetReasonablePlanningBehavior(URpaiComposerBehavior* NewBehavior);
 
+#if WITH_EDITOR
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+
+	// Component Lifecycle
+	virtual void OnRegister() override;
+
 protected:
-	virtual const URpaiReasonerBase* AcquireReasoner_Implementation();
-	virtual const URpaiPlannerBase* AcquirePlanner_Implementation();
-	virtual void AcquireGoals_Implementation(TArray<URpaiGoalBase*>& OutGoals);
-	virtual void AcquireActions_Implementation(TArray<URpaiActionBase*>& OutActions);
-	virtual TSubclassOf<URpaiState> GetStateType_Implementation();
+	virtual const URpaiReasonerBase* AcquireReasoner_Implementation() override;
+	virtual const URpaiPlannerBase* AcquirePlanner_Implementation() override;
+	virtual void AcquireGoals_Implementation(TArray<URpaiGoalBase*>& OutGoals) override;
+	virtual void AcquireActions_Implementation(TArray<URpaiActionBase*>& OutActions) override;
 
 private:
 	UPROPERTY(EditDefaultsOnly, Category = "Rpai")

--- a/Source/ReasonablePlanningAI/ReasonablePlanningAI.Build.cs
+++ b/Source/ReasonablePlanningAI/ReasonablePlanningAI.Build.cs
@@ -23,6 +23,7 @@ public class ReasonablePlanningAI : ModuleRules
 				"GameplayTags",
 				"GameplayTasks",
 				"NavigationSystem",
+                "PropertyPath"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);
@@ -34,8 +35,7 @@ public class ReasonablePlanningAI : ModuleRules
 				"CoreUObject",
 				"Engine",
 				"Slate",
-				"SlateCore",
-				"PropertyPath"
+				"SlateCore"
 				// ... add private dependencies that you statically link with here ...	
 			}
 			);

--- a/Source/ReasonablePlanningAITestSuite/Public/ReasonablePlanningAITestTypes.h
+++ b/Source/ReasonablePlanningAITestSuite/Public/ReasonablePlanningAITestTypes.h
@@ -111,5 +111,19 @@ struct FTestStruct
 {
 	GENERATED_BODY()
 
+	UPROPERTY()
 	int32 Value;
+};
+
+
+USTRUCT(BlueprintType)
+struct FComplexTestStruct
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	float Value;
+
+	UPROPERTY()
+	FTestStruct Inner;
 };

--- a/Source/ReasonablePlanningAITestSuite/ReasonablePlanningAITestSuite.Build.cs
+++ b/Source/ReasonablePlanningAITestSuite/ReasonablePlanningAITestSuite.Build.cs
@@ -24,7 +24,8 @@ namespace UnrealBuildTool.Rules
 
             PrivateDependencyModuleNames.AddRange(
                 new[] {
-                    "UnrealEd"
+                    "UnrealEd",
+                    "PropertyPath"
                 }
             );
 


### PR DESCRIPTION
This change fundamentally changes the strategy for configuring the transfer of state within the RPAI system. It **should** maintain backwards compatibility for this iteration.

- The state type is now defined in the base component
  - For support, the behavior state type is copied over when using the composer system to create RPAI.
  - The default state will cause an error during runtime.
- Added the Property Path helper module as a public dependency (add it to your project as it is now part of the interface)
- Binding handles are supported by the editor in the open source edition. Will have enhancements for marketplace edition.

The ultimate goal of this PR is two part.
1) Data driven configuration of copying game data to state nodes.
2) Prepare for another refactor of the Planners to use untracked objects and fix for memory bound issues with planners.