### PR TITLE
[FIX] 5.5 Build

### DIFF
--- a/Source/ReasonablePlanningAIEditor/StateQueryComparisonCustom.cpp
+++ b/Source/ReasonablePlanningAIEditor/StateQueryComparisonCustom.cpp
@@ -7,12 +7,12 @@
 
 TSharedRef<IDetailCustomization> StateQueryComparisonCustom::MakeInstance(FName RHSFieldName)
 {
-    return MakeShareable(new StateQueryComparisonCustom(RHSFieldName));
+    return MakeShareable<IDetailCustomization>(new StateQueryComparisonCustom(RHSFieldName));
 }
 
 TSharedRef<IPropertyTypeCustomization> StateQueryComparisonCustom::MakePropertyInstance(FName RHSFieldName)
 {
-	return MakeShareable(new StateQueryComparisonCustom(RHSFieldName));
+	return MakeShareable<IPropertyTypeCustomization> (new StateQueryComparisonCustom(RHSFieldName));
 }
 
 StateQueryComparisonCustom::StateQueryComparisonCustom(FName RHSFieldName)

--- a/Source/ReasonablePlanningAITestSuite/Private/ComposerActionTaskTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/ComposerActionTaskTests.cpp
@@ -35,7 +35,7 @@ void UTestComposerActionTask::ReceiveCompleteActionTask_Implementation(AAIContro
 	++CompleteActionTaskCallsTotal;
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningComposerActionTaskSequenceSpec, "ReasonablePlanningAI.Composer.ActionTask", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningComposerActionTaskSequenceSpec, "ReasonablePlanningAI.Composer.ActionTask", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	AAIController* GivenController;
 	URpaiActionTask_Sequence* ActionTaskUnderTest;
 	FRpaiMemory GivenPool;
@@ -176,7 +176,7 @@ void ReasonablePlanningComposerActionTaskSequenceSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningComposerActionTaskComposerSpec, "ReasonablePlanningAI.Composer.ActionTask", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningComposerActionTaskComposerSpec, "ReasonablePlanningAI.Composer.ActionTask", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	AAIController* GivenController;
 	URpaiActionTask_Composite* ActionTaskUnderTest;
 	FRpaiMemory GivenPool;

--- a/Source/ReasonablePlanningAITestSuite/Private/ComposerTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/ComposerTests.cpp
@@ -42,7 +42,7 @@
 #include "Composer/Weights/RpaiWeight_Distance.h"
 #include "Composer/Weights/RpaiWeight_Select.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningComposerSpec, "ReasonablePlanningAI.Composer", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningComposerSpec, "ReasonablePlanningAI.Composer", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiPlannerBase* GivenPlanner;
 	URpaiReasonerBase* GivenReasoner;
 	URpaiState* GivenState;

--- a/Source/ReasonablePlanningAITestSuite/Private/DistanceTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/DistanceTests.cpp
@@ -10,7 +10,7 @@
 #include "Composer/Distances/RpaiDistance_CurveFloat.h"
 #include "States/RpaiState_Map.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceBoolSpec, "ReasonablePlanningAI.Distance.Bool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceBoolSpec, "ReasonablePlanningAI.Distance.Bool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
     URpaiDistance_Bool* ClassUnderTest;
     URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceBoolSpec)
@@ -119,7 +119,7 @@ void ReasonablePlanningDistanceBoolSpec::Define()
         });
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceFloatSpec, "ReasonablePlanningAI.Distance.Float", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceFloatSpec, "ReasonablePlanningAI.Distance.Float", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiDistance_Float* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceFloatSpec)
@@ -208,7 +208,7 @@ void ReasonablePlanningDistanceFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceIntegerSpec, "ReasonablePlanningAI.Distance.Integer", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceIntegerSpec, "ReasonablePlanningAI.Distance.Integer", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiDistance_Integer* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceIntegerSpec)
@@ -302,7 +302,7 @@ void ReasonablePlanningDistanceIntegerSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceRotatorSpec, "ReasonablePlanningAI.Distance.Rotator", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceRotatorSpec, "ReasonablePlanningAI.Distance.Rotator", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiDistance_Rotator* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceRotatorSpec)
@@ -394,7 +394,7 @@ void ReasonablePlanningDistanceRotatorSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceVectorSpec, "ReasonablePlanningAI.Distance.Vector", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceVectorSpec, "ReasonablePlanningAI.Distance.Vector", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiDistance_Vector* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceVectorSpec)
@@ -486,7 +486,7 @@ void ReasonablePlanningDistanceVectorSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceStateSpec, "ReasonablePlanningAI.Distance.State", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceStateSpec, "ReasonablePlanningAI.Distance.State", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
     URpaiDistance_State* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningDistanceStateSpec)
@@ -656,7 +656,7 @@ void ReasonablePlanningDistanceStateSpec::Define()
 
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceCurveFloatSpec, "ReasonablePlanningAI.Distance.CurveFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningDistanceCurveFloatSpec, "ReasonablePlanningAI.Distance.CurveFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 URpaiDistance_CurveFloat* ClassUnderTest;
 URpaiDistance_Float* GivenDistance;
 URpaiState* GivenState;

--- a/Source/ReasonablePlanningAITestSuite/Private/Functional/RpaiActionTask_MoveToTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/Functional/RpaiActionTask_MoveToTests.cpp
@@ -92,7 +92,7 @@ bool FExecuteSimpleMoveToActionTaskLatentCommand::Update()
     return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FRpaiActionTask_MoveTo_PawnShouldMove, "ReasonablePlanningAI.Composer.Functional.ActionTask_MoveTo", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FRpaiActionTask_MoveTo_PawnShouldMove, "ReasonablePlanningAI.Composer.Functional.ActionTask_MoveTo", EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 bool FRpaiActionTask_MoveTo_PawnShouldMove::RunTest(const FString& Parameters)
 {
     ADD_LATENT_AUTOMATION_COMMAND(FEditorLoadMap("/ReasonablePlanningAI/RpaiAutomationTestWorld"));

--- a/Source/ReasonablePlanningAITestSuite/Private/MemoryTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/MemoryTests.cpp
@@ -3,7 +3,7 @@
 #include "ReasonablePlanningAITestTypes.h"
 
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMemoryTests, "ReasonablePlanningAI.Core.Memory", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMemoryTests, "ReasonablePlanningAI.Core.Memory", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 END_DEFINE_SPEC(ReasonablePlanningMemoryTests)
 void ReasonablePlanningMemoryTests::Define()
 {

--- a/Source/ReasonablePlanningAITestSuite/Private/MutatorTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/MutatorTests.cpp
@@ -15,7 +15,7 @@
 #include "Composer/Mutators/RpaiStateMutator_SetValueVector.h"
 #include "Composer/Mutators/RpaiStateMutator_CopyState.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorAddFloatSpec, "ReasonablePlanningAI.Mutators.AddFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorAddFloatSpec, "ReasonablePlanningAI.Mutators.AddFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_AddFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorAddFloatSpec)
@@ -63,7 +63,7 @@ void ReasonablePlanningMutatorAddFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorAddIntegerSpec, "ReasonablePlanningAI.Mutators.AddInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorAddIntegerSpec, "ReasonablePlanningAI.Mutators.AddInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_AddInteger* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorAddIntegerSpec)
@@ -111,7 +111,7 @@ void ReasonablePlanningMutatorAddIntegerSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyFloatSpec, "ReasonablePlanningAI.Mutators.MultiplyFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyFloatSpec, "ReasonablePlanningAI.Mutators.MultiplyFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_MultiplyFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyFloatSpec)
@@ -172,7 +172,7 @@ void ReasonablePlanningMutatorMultiplyFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyIntegerSpec, "ReasonablePlanningAI.Mutators.MulitplyInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyIntegerSpec, "ReasonablePlanningAI.Mutators.MulitplyInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_MultiplyInteger* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorMultiplyIntegerSpec)
@@ -209,7 +209,7 @@ void ReasonablePlanningMutatorMultiplyIntegerSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetBoolSpec, "ReasonablePlanningAI.Mutators.SetBool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetBoolSpec, "ReasonablePlanningAI.Mutators.SetBool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueBool* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetBoolSpec)
@@ -246,7 +246,7 @@ void ReasonablePlanningMutatorSetBoolSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetClassSpec, "ReasonablePlanningAI.Mutators.SetClass", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetClassSpec, "ReasonablePlanningAI.Mutators.SetClass", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueClass* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetClassSpec)
@@ -283,7 +283,7 @@ void ReasonablePlanningMutatorSetClassSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetFloatSpec, "ReasonablePlanningAI.Mutators.SetFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetFloatSpec, "ReasonablePlanningAI.Mutators.SetFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetFloatSpec)
@@ -320,7 +320,7 @@ void ReasonablePlanningMutatorSetFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetIntegerSpec, "ReasonablePlanningAI.Mutators.SetInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetIntegerSpec, "ReasonablePlanningAI.Mutators.SetInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueInteger* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetIntegerSpec)
@@ -357,7 +357,7 @@ void ReasonablePlanningMutatorSetIntegerSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetNameSpec, "ReasonablePlanningAI.Mutators.SetName", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetNameSpec, "ReasonablePlanningAI.Mutators.SetName", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueName* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetNameSpec)
@@ -394,7 +394,7 @@ void ReasonablePlanningMutatorSetNameSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetRotatorSpec, "ReasonablePlanningAI.Mutators.SetRotator", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetRotatorSpec, "ReasonablePlanningAI.Mutators.SetRotator", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueRotator* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetRotatorSpec)
@@ -432,7 +432,7 @@ void ReasonablePlanningMutatorSetRotatorSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetStringSpec, "ReasonablePlanningAI.Mutators.SetString", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetStringSpec, "ReasonablePlanningAI.Mutators.SetString", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueString* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetStringSpec)
@@ -470,7 +470,7 @@ void ReasonablePlanningMutatorSetStringSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetVectorSpec, "ReasonablePlanningAI.Mutators.SetVector", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorSetVectorSpec, "ReasonablePlanningAI.Mutators.SetVector", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_SetValueVector* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorSetVectorSpec)
@@ -508,7 +508,7 @@ void ReasonablePlanningMutatorSetVectorSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorCopyStateSpec, "ReasonablePlanningAI.Mutators.CopyState", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningMutatorCopyStateSpec, "ReasonablePlanningAI.Mutators.CopyState", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateMutator_CopyState* ClassUnderTest;
 	URpaiState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningMutatorCopyStateSpec)

--- a/Source/ReasonablePlanningAITestSuite/Private/PlannerTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/PlannerTests.cpp
@@ -4,7 +4,7 @@
 #include "Planners/RpaiPlanner_HUG.h"
 #include "States/RpaiState_Map.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningPlannerImplSpec, "ReasonablePlanningAI.Planners", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningPlannerImplSpec, "ReasonablePlanningAI.Planners", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiPlannerBase* ClassUnderTest;
 	URpaiState* GivenState;
 	URpaiGoalBase* GivenGoal;

--- a/Source/ReasonablePlanningAITestSuite/Private/QueryTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/QueryTests.cpp
@@ -6,7 +6,7 @@
 #include "Composer/Queries/RpaiStateQuery_CompareToStateValue.h"
 #include "States/RpaiState_Map.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToBoolSpec, "ReasonablePlanningAI.Queries.CompareBool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToBoolSpec, "ReasonablePlanningAI.Queries.CompareBool", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateQuery_CompareToBool* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningQueryCompareToBoolSpec)
@@ -94,7 +94,7 @@ void ReasonablePlanningQueryCompareToBoolSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToFloatSpec, "ReasonablePlanningAI.Queries.CompareFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToFloatSpec, "ReasonablePlanningAI.Queries.CompareFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateQuery_CompareToFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningQueryCompareToFloatSpec)
@@ -182,7 +182,7 @@ void ReasonablePlanningQueryCompareToFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToIntegerSpec, "ReasonablePlanningAI.Queries.CompareInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToIntegerSpec, "ReasonablePlanningAI.Queries.CompareInteger", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateQuery_CompareToInteger* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningQueryCompareToIntegerSpec)
@@ -270,7 +270,7 @@ void ReasonablePlanningQueryCompareToIntegerSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToStateSpec, "ReasonablePlanningAI.Queries.CompareState", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningQueryCompareToStateSpec, "ReasonablePlanningAI.Queries.CompareState", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiStateQuery_CompareToStateValue* ClassUnderTest;
 	URpaiState_Map* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningQueryCompareToStateSpec)

--- a/Source/ReasonablePlanningAITestSuite/Private/ReasonerTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/ReasonerTests.cpp
@@ -4,7 +4,7 @@
 #include "Reasoners/RpaiReasoner_AbsoluteUtility.h"
 #include "States/RpaiState_Map.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningReasonersSpec, "ReasonablePlanningAI.Reasoners", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningReasonersSpec, "ReasonablePlanningAI.Reasoners", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiReasonerBase* ClassUnderTest;
 	URpaiState* GivenState;
 	TArray<URpaiGoalBase*> GivenGoals;

--- a/Source/ReasonablePlanningAITestSuite/Private/ResourceCollectionTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/ResourceCollectionTests.cpp
@@ -2,7 +2,7 @@
 #include "ReasonablePlanningAITestTypes.h"
 #include "Core/RpaiResourceCollection.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningResourceCollectionSpec, "ReasonablePlanningAI.ResourceCollection", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningResourceCollectionSpec, "ReasonablePlanningAI.ResourceCollection", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiResourceCollection* ClassUnderTest;
 	URpaiResourceCollection* LockingObject;
 END_DEFINE_SPEC(ReasonablePlanningResourceCollectionSpec)

--- a/Source/ReasonablePlanningAITestSuite/Private/StateTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/StateTests.cpp
@@ -4,7 +4,7 @@
 #include "States/RpaiState_Reflection.h"
 #include "ReasonablePlanningAITestTypes.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningStateMapSpec, "ReasonablePlanningAI.StateMap", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningStateMapSpec, "ReasonablePlanningAI.StateMap", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiState_Map* ClassUnderTest;
 END_DEFINE_SPEC(ReasonablePlanningStateMapSpec)
 void ReasonablePlanningStateMapSpec::Define()
@@ -444,7 +444,7 @@ void ReasonablePlanningStateMapSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningStateReflectionSpec, "ReasonablePlanningAI.StateReflection", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningStateReflectionSpec, "ReasonablePlanningAI.StateReflection", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiState_Reflection* ClassUnderTest;
 END_DEFINE_SPEC(ReasonablePlanningStateReflectionSpec)
 void ReasonablePlanningStateReflectionSpec::Define()
@@ -672,7 +672,7 @@ void ReasonablePlanningStateReflectionSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningStateBindingSpec, "ReasonablePlanningAI.StateBinding", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningStateBindingSpec, "ReasonablePlanningAI.StateBinding", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiState* SourceState;
 END_DEFINE_SPEC(ReasonablePlanningStateBindingSpec)
 void ReasonablePlanningStateBindingSpec::Define()

--- a/Source/ReasonablePlanningAITestSuite/Private/WeightTests.cpp
+++ b/Source/ReasonablePlanningAITestSuite/Private/WeightTests.cpp
@@ -5,7 +5,7 @@
 #include "Composer/Weights/RpaiWeight_CurveFloat.h"
 #include "Composer/Weights/RpaiWeight_ConstantFloat.h"
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningWeightConstantFloatSpec, "ReasonablePlanningAI.Weights.ConstantFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningWeightConstantFloatSpec, "ReasonablePlanningAI.Weights.ConstantFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiWeight_ConstantFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningWeightConstantFloatSpec)
@@ -40,7 +40,7 @@ void ReasonablePlanningWeightConstantFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningWeightFloatSpec, "ReasonablePlanningAI.Weights.Float", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningWeightFloatSpec, "ReasonablePlanningAI.Weights.Float", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiWeight_Float* ClassUnderTest;
 	UTestPlanningState* GivenState;
 END_DEFINE_SPEC(ReasonablePlanningWeightFloatSpec)
@@ -82,7 +82,7 @@ void ReasonablePlanningWeightFloatSpec::Define()
 		});
 }
 
-BEGIN_DEFINE_SPEC(ReasonablePlanningWeightCurveFloatSpec, "ReasonablePlanningAI.Weights.CurveFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+BEGIN_DEFINE_SPEC(ReasonablePlanningWeightCurveFloatSpec, "ReasonablePlanningAI.Weights.CurveFloat", EAutomationTestFlags::ProductFilter | EAutomationTestFlags_ApplicationContextMask)
 	URpaiWeight_CurveFloat* ClassUnderTest;
 	UTestPlanningState* GivenState;
 	UCurveFloat* GivenCurve;


### PR DESCRIPTION
FIX: epic created breaking changes in enum definitions, type coercion was failing. Fix for build in 5.5